### PR TITLE
fix: polish boot theme and browser runtime sync

### DIFF
--- a/Linux/NixOS/home/noctalia/config/settings.json
+++ b/Linux/NixOS/home/noctalia/config/settings.json
@@ -40,7 +40,7 @@
   "bar": {
     "autoHideDelay": 500,
     "autoShowDelay": 150,
-    "backgroundOpacity": 0.7000000000000001,
+    "backgroundOpacity": 0.8,
     "barType": "floating",
     "capsuleColorKey": "none",
     "capsuleOpacity": 0.8,

--- a/Linux/NixOS/themes/grub-theme/theme.txt
+++ b/Linux/NixOS/themes/grub-theme/theme.txt
@@ -10,34 +10,32 @@ terminal-height: "100%"
 terminal-border: "0"
 
 + image {
-  left = 50%-72
-  top = 7%
-  width = 144
-  height = 144
+  left = 50%-160
+  top = 28%
   file = "logo.png"
 }
 
 + boot_menu {
-  left = 50%-280
-  top = 42%
-  width = 560
-  height = 34%
+  left = 50%-240
+  top = 60%
+  width = 480
+  height = 30%
   item_font = "Unifont Regular 16"
   item_color = "#CDD6F4"
   selected_item_color = "#CBA6F7"
   icon_width = 32
   icon_height = 32
   item_icon_space = 20
-  item_height = 38
-  item_padding = 6
+  item_height = 36
+  item_padding = 5
   item_spacing = 10
   selected_item_pixmap_style = "select_*.png"
 }
 
 + label {
-  left = 50%-192
-  top = 86%
-  width = 384
+  left = 35%
+  top = 82%
+  width = 30%
   align = "center"
   id = "__timeout__"
   text = "Booting in %d seconds"

--- a/Linux/installer/internal/dots/zen_sine.go
+++ b/Linux/installer/internal/dots/zen_sine.go
@@ -17,6 +17,13 @@ const (
 	zenCustomCSSPrefLine = `user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);`
 )
 
+var sineChromePreservePaths = []string{
+	"/JS/",
+	"/locales/",
+	"/sine-mods/",
+	"/utils/",
+}
+
 func setupZen(ctx context.Context, runner run.CommandRunner, dotsSrc, home, username string, cfg config.Dots) error {
 	profile := zenutil.FindProfile(home)
 	if profile == "" {
@@ -68,7 +75,12 @@ func setupZenTheme(ctx context.Context, runner run.CommandRunner, dotsSrc, chrom
 	if err := ensureUserWritableTree(ctx, runner, chrome, username); err != nil {
 		return err
 	}
-	if err := runner.Command(ctx, "rsync", "-a", "--delete", src+"/", chrome+"/"); err != nil {
+	args := []string{"-a", "--delete"}
+	for _, rel := range sineChromePreservePaths {
+		args = append(args, "--exclude", rel)
+	}
+	args = append(args, src+"/", chrome+"/")
+	if err := runner.Command(ctx, "rsync", args...); err != nil {
 		return err
 	}
 	if err := ensureUserWritableTree(ctx, runner, chrome, username); err != nil {

--- a/Linux/installer/internal/dots/zen_test.go
+++ b/Linux/installer/internal/dots/zen_test.go
@@ -177,6 +177,39 @@ func TestSetupZenThemeDoesNotBackupManagedChrome(t *testing.T) {
 	}
 }
 
+func TestSetupZenThemePreservesSineChromeFiles(t *testing.T) {
+	dotsSrc := t.TempDir()
+	src := filepath.Join(dotsSrc, "zen", "chrome")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "userChrome.css"), []byte("/* updated theme */\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chrome := t.TempDir()
+	if err := os.WriteFile(filepath.Join(chrome, ".mysetup-managed.json"), []byte(managedMarkerWithSourceHash("zen-chrome", "old-source-hash")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	runner := run.Runner{DryRun: true, Stdout: &out, Stderr: &out}
+	if err := setupZenTheme(context.Background(), runner, dotsSrc, chrome, "tester"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"--exclude /JS/",
+		"--exclude /utils/",
+		"--exclude /sine-mods/",
+		"--exclude /locales/",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected Zen theme rsync to preserve Sine path %q, got:\n%s", want, got)
+		}
+	}
+}
+
 func TestEnsureZenCustomCSSPrefCreatesUserJS(t *testing.T) {
 	profile := t.TempDir()
 


### PR DESCRIPTION
## What

- Align GRUB boot theme logo/menu placement with the Plymouth visual layout
- Set Noctalia default opacity explicitly
- Preserve Sine-owned Zen chrome files during Catppuccin chrome sync

## Why

This keeps the boot screens visually consistent and avoids browser runtime regressions after rebuilds. The Zen chrome sync previously used `rsync --delete` over the whole profile `chrome` directory, which could remove Sine files before reinstalling them and make Sine appear missing until Zen was restarted.

## Testing

- `go test ./...`
- `git diff --check`