### PR TITLE
chore(nix): update noctalia to v5.0.0-beta.5

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -639,16 +639,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784820380,
-        "narHash": "sha256-jXz2vFHgidbyU46ScROLSuBIhsqqtyqNu2M0tmGX/FA=",
+        "lastModified": 1785005717,
+        "narHash": "sha256-iq/Eqx62P/JJDpW7CgEsMWWPwOexIWRKXtqKF/drawA=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "4c2dcd0995f9c570c0ced95561bf5e4685e2ad1b",
+        "rev": "3d7b9869950592ff7cf3704f6a53afb169d850db",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.4",
+        "ref": "v5.0.0-beta.5",
         "repo": "noctalia",
         "type": "github"
       }

--- a/Linux/NixOS/flake.nix
+++ b/Linux/NixOS/flake.nix
@@ -28,7 +28,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.4";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {

--- a/flake.lock
+++ b/flake.lock
@@ -598,16 +598,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1784820380,
-        "narHash": "sha256-jXz2vFHgidbyU46ScROLSuBIhsqqtyqNu2M0tmGX/FA=",
+        "lastModified": 1785005717,
+        "narHash": "sha256-iq/Eqx62P/JJDpW7CgEsMWWPwOexIWRKXtqKF/drawA=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "4c2dcd0995f9c570c0ced95561bf5e4685e2ad1b",
+        "rev": "3d7b9869950592ff7cf3704f6a53afb169d850db",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.4",
+        "ref": "v5.0.0-beta.5",
         "repo": "noctalia",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.4";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {


### PR DESCRIPTION
## What

Pins `noctalia` to `v5.0.0-beta.5`, in both the root flake and `Linux/NixOS`.

## Why

Keeps the deployed Noctalia shell current without every routine `nix flake update` yanking in an unstable `main` commit and forcing a from-scratch local rebuild.

## Testing

- Evaluated the public shell module and the NixOS Noctalia package derivation.
- Built only the updated Noctalia package.