### PR TITLE
chore(nix): update noctalia to v5.0.0-beta.6

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -639,16 +639,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785005717,
-        "narHash": "sha256-iq/Eqx62P/JJDpW7CgEsMWWPwOexIWRKXtqKF/drawA=",
+        "lastModified": 1785191981,
+        "narHash": "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "3d7b9869950592ff7cf3704f6a53afb169d850db",
+        "rev": "d24fe45e9a798317072547fa5d56950607750e68",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.5",
+        "ref": "v5.0.0-beta.6",
         "repo": "noctalia",
         "type": "github"
       }

--- a/Linux/NixOS/flake.nix
+++ b/Linux/NixOS/flake.nix
@@ -28,7 +28,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.5";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {

--- a/flake.lock
+++ b/flake.lock
@@ -598,16 +598,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785005717,
-        "narHash": "sha256-iq/Eqx62P/JJDpW7CgEsMWWPwOexIWRKXtqKF/drawA=",
+        "lastModified": 1785191981,
+        "narHash": "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "3d7b9869950592ff7cf3704f6a53afb169d850db",
+        "rev": "d24fe45e9a798317072547fa5d56950607750e68",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.5",
+        "ref": "v5.0.0-beta.6",
         "repo": "noctalia",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.5";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {


### PR DESCRIPTION
## What

Pins `noctalia` to `v5.0.0-beta.6`, in both the root flake and `Linux/NixOS`.

## Why

Keeps the deployed Noctalia shell current without every routine `nix flake update` yanking in an unstable `main` commit and forcing a from-scratch local rebuild.

## Testing

- Evaluated the public shell module and the NixOS Noctalia package derivation.
- Built only the updated Noctalia package.