### PR TITLE
chore(nix): update noctalia to v5.0.0-beta.7

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -678,16 +678,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785191981,
-        "narHash": "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=",
+        "lastModified": 1785444393,
+        "narHash": "sha256-9RlJNIy2DFVm9SB2vwGEBsbHc1r3dIB+K+b+nd6Bdho=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "d24fe45e9a798317072547fa5d56950607750e68",
+        "rev": "c366a35ffc30b011d03fcd122bbe7d22f932fc57",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.6",
+        "ref": "v5.0.0-beta.7",
         "repo": "noctalia",
         "type": "github"
       }

--- a/Linux/NixOS/flake.nix
+++ b/Linux/NixOS/flake.nix
@@ -27,7 +27,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {

--- a/Linux/NixOS/lib/preset-inputs.nix
+++ b/Linux/NixOS/lib/preset-inputs.nix
@@ -62,7 +62,7 @@ let
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {

--- a/Linux/NixOS/presets/desktop/flake.lock
+++ b/Linux/NixOS/presets/desktop/flake.lock
@@ -507,16 +507,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785191981,
-        "narHash": "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=",
+        "lastModified": 1785444393,
+        "narHash": "sha256-9RlJNIy2DFVm9SB2vwGEBsbHc1r3dIB+K+b+nd6Bdho=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "d24fe45e9a798317072547fa5d56950607750e68",
+        "rev": "c366a35ffc30b011d03fcd122bbe7d22f932fc57",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.6",
+        "ref": "v5.0.0-beta.7",
         "repo": "noctalia",
         "type": "github"
       }

--- a/Linux/NixOS/presets/desktop/flake.nix
+++ b/Linux/NixOS/presets/desktop/flake.nix
@@ -48,7 +48,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -624,16 +624,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785191981,
-        "narHash": "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=",
+        "lastModified": 1785444393,
+        "narHash": "sha256-9RlJNIy2DFVm9SB2vwGEBsbHc1r3dIB+K+b+nd6Bdho=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "d24fe45e9a798317072547fa5d56950607750e68",
+        "rev": "c366a35ffc30b011d03fcd122bbe7d22f932fc57",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.6",
+        "ref": "v5.0.0-beta.7",
         "repo": "noctalia",
         "type": "github"
       }

--- a/Linux/NixOS/presets/developer/flake.nix
+++ b/Linux/NixOS/presets/developer/flake.nix
@@ -48,7 +48,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -624,16 +624,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785191981,
-        "narHash": "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=",
+        "lastModified": 1785444393,
+        "narHash": "sha256-9RlJNIy2DFVm9SB2vwGEBsbHc1r3dIB+K+b+nd6Bdho=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "d24fe45e9a798317072547fa5d56950607750e68",
+        "rev": "c366a35ffc30b011d03fcd122bbe7d22f932fc57",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.6",
+        "ref": "v5.0.0-beta.7",
         "repo": "noctalia",
         "type": "github"
       }

--- a/Linux/NixOS/presets/personal/flake.nix
+++ b/Linux/NixOS/presets/personal/flake.nix
@@ -48,7 +48,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {

--- a/flake.lock
+++ b/flake.lock
@@ -637,16 +637,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1785191981,
-        "narHash": "sha256-VJXqeaxCqyMOt/k7ePNoD4nAHdF1eTSuuddmrh/5O6Q=",
+        "lastModified": 1785444393,
+        "narHash": "sha256-9RlJNIy2DFVm9SB2vwGEBsbHc1r3dIB+K+b+nd6Bdho=",
         "owner": "noctalia-dev",
         "repo": "noctalia",
-        "rev": "d24fe45e9a798317072547fa5d56950607750e68",
+        "rev": "c366a35ffc30b011d03fcd122bbe7d22f932fc57",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "ref": "v5.0.0-beta.6",
+        "ref": "v5.0.0-beta.7",
         "repo": "noctalia",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia = {
-      url = "github:noctalia-dev/noctalia/v5.0.0-beta.6";
+      url = "github:noctalia-dev/noctalia/v5.0.0-beta.7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     noctalia-shell = {


### PR DESCRIPTION
## What

Pins `noctalia` to `v5.0.0-beta.7`, in the root, full NixOS, and desktop-or-higher preset flakes.

## Why

Keeps the deployed Noctalia shell current without every routine `nix flake update` yanking in an unstable `main` commit and forcing a from-scratch local rebuild.

## Testing

- Evaluated the public shell module and the NixOS Noctalia package derivation.
- Built only the updated Noctalia package.