### PR TITLE
chore(nix): update omnirouter to v3.8.49

### DIFF
--- a/Linux/NixOS/pkgs/omnirouter.nix
+++ b/Linux/NixOS/pkgs/omnirouter.nix
@@ -21,16 +21,16 @@ let
 in
 buildNpmPackage' rec {
   pname = "omnirouter";
-  version = "3.8.48";
+  version = "3.8.49";
 
   src = fetchFromGitHub {
     owner = "diegosouzapw";
     repo = "OmniRoute";
-    rev = "v3.8.48";
-    hash = "sha256-lqw0M0mHqsMWWvz7X+3sO+FbaVmJ9bL9FBgB5HxsUBI=";
+    rev = "v3.8.49";
+    hash = "sha256-nRLziV4NWPoa0ev57DV7jmAvLpL/1MP1EMZO2/drrTU=";
   };
 
-  npmDepsHash = "sha256-pVq6fpF0d1FeJmZm4rGcV0wjpoFcDmlhY254Muo00qI=";
+  npmDepsHash = "sha256-R0u93MLUUWC8xFgq4S0Aj/7wg4pygTKwxP/eWkWMgCw=";
 
   nativeBuildInputs = [
     python311


### PR DESCRIPTION
## What

Updates local `omnirouter` package to `v3.8.49`.

Updated hashes:
- source: `sha256-nRLziV4NWPoa0ev57DV7jmAvLpL/1MP1EMZO2/drrTU=`
- npmDepsHash: `sha256-R0u93MLUUWC8xFgq4S0Aj/7wg4pygTKwxP/eWkWMgCw=`

## Why

Keeps the packaged OmniRouter release current.

## Testing

- `nix build --no-link --print-build-logs --no-write-lock-file "$FLAKE#omnirouter"`