### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786094046,
-        "narHash": "sha256-1M6mHYUWDpQeLuv86qkbVZjkvEhrxjG3AFD3vxLpWwo=",
+        "lastModified": 1786103990,
+        "narHash": "sha256-QOU1NhjmGZvsgxv+4TwMqgWyHBMupLtGuSdzK2OS+tY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "4d429d78441cef3f721a408d3daa2328d91b1935",
+        "rev": "13999326ebec71edc9ce7bc832632be4fc08f260",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786094046,
-        "narHash": "sha256-1M6mHYUWDpQeLuv86qkbVZjkvEhrxjG3AFD3vxLpWwo=",
+        "lastModified": 1786103990,
+        "narHash": "sha256-QOU1NhjmGZvsgxv+4TwMqgWyHBMupLtGuSdzK2OS+tY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "4d429d78441cef3f721a408d3daa2328d91b1935",
+        "rev": "13999326ebec71edc9ce7bc832632be4fc08f260",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786094046,
-        "narHash": "sha256-1M6mHYUWDpQeLuv86qkbVZjkvEhrxjG3AFD3vxLpWwo=",
+        "lastModified": 1786103990,
+        "narHash": "sha256-QOU1NhjmGZvsgxv+4TwMqgWyHBMupLtGuSdzK2OS+tY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "4d429d78441cef3f721a408d3daa2328d91b1935",
+        "rev": "13999326ebec71edc9ce7bc832632be4fc08f260",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786094046,
-        "narHash": "sha256-1M6mHYUWDpQeLuv86qkbVZjkvEhrxjG3AFD3vxLpWwo=",
+        "lastModified": 1786103990,
+        "narHash": "sha256-QOU1NhjmGZvsgxv+4TwMqgWyHBMupLtGuSdzK2OS+tY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "4d429d78441cef3f721a408d3daa2328d91b1935",
+        "rev": "13999326ebec71edc9ce7bc832632be4fc08f260",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.