### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786276477,
-        "narHash": "sha256-C+5hkjIoYRoHQUXxhW5Skvej7NmW7zbRueLCauCJvDU=",
+        "lastModified": 1786282382,
+        "narHash": "sha256-Yy+w9I3+Dd3gTOBtVcmyUcfyh0c31ZsBPFSspbVrdSY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "a638aecace9e13b11bfe4e927091c8bd93ed6e04",
+        "rev": "627ab887d86725d4f29838ecdc46c6985cd7ad2c",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786276477,
-        "narHash": "sha256-C+5hkjIoYRoHQUXxhW5Skvej7NmW7zbRueLCauCJvDU=",
+        "lastModified": 1786282382,
+        "narHash": "sha256-Yy+w9I3+Dd3gTOBtVcmyUcfyh0c31ZsBPFSspbVrdSY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "a638aecace9e13b11bfe4e927091c8bd93ed6e04",
+        "rev": "627ab887d86725d4f29838ecdc46c6985cd7ad2c",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786276477,
-        "narHash": "sha256-C+5hkjIoYRoHQUXxhW5Skvej7NmW7zbRueLCauCJvDU=",
+        "lastModified": 1786282382,
+        "narHash": "sha256-Yy+w9I3+Dd3gTOBtVcmyUcfyh0c31ZsBPFSspbVrdSY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "a638aecace9e13b11bfe4e927091c8bd93ed6e04",
+        "rev": "627ab887d86725d4f29838ecdc46c6985cd7ad2c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786276477,
-        "narHash": "sha256-C+5hkjIoYRoHQUXxhW5Skvej7NmW7zbRueLCauCJvDU=",
+        "lastModified": 1786282382,
+        "narHash": "sha256-Yy+w9I3+Dd3gTOBtVcmyUcfyh0c31ZsBPFSspbVrdSY=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "a638aecace9e13b11bfe4e927091c8bd93ed6e04",
+        "rev": "627ab887d86725d4f29838ecdc46c6985cd7ad2c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.