### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786350885,
-        "narHash": "sha256-NNRHhc8/Rq4OpRUCGGSyYvzDNqxI1DpYkEKZvDMT8CM=",
+        "lastModified": 1786358182,
+        "narHash": "sha256-JVJX1innDJZoaMmTurwM+4LowjdQsjmXsyAnQVp9lGE=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "afc4b9ae00516f9e2edec9439cb7fd680006ea88",
+        "rev": "d00ee7080fa9375e959eb44035bd068c9900e62b",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786350885,
-        "narHash": "sha256-NNRHhc8/Rq4OpRUCGGSyYvzDNqxI1DpYkEKZvDMT8CM=",
+        "lastModified": 1786358182,
+        "narHash": "sha256-JVJX1innDJZoaMmTurwM+4LowjdQsjmXsyAnQVp9lGE=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "afc4b9ae00516f9e2edec9439cb7fd680006ea88",
+        "rev": "d00ee7080fa9375e959eb44035bd068c9900e62b",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786350885,
-        "narHash": "sha256-NNRHhc8/Rq4OpRUCGGSyYvzDNqxI1DpYkEKZvDMT8CM=",
+        "lastModified": 1786358182,
+        "narHash": "sha256-JVJX1innDJZoaMmTurwM+4LowjdQsjmXsyAnQVp9lGE=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "afc4b9ae00516f9e2edec9439cb7fd680006ea88",
+        "rev": "d00ee7080fa9375e959eb44035bd068c9900e62b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786350885,
-        "narHash": "sha256-NNRHhc8/Rq4OpRUCGGSyYvzDNqxI1DpYkEKZvDMT8CM=",
+        "lastModified": 1786358182,
+        "narHash": "sha256-JVJX1innDJZoaMmTurwM+4LowjdQsjmXsyAnQVp9lGE=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "afc4b9ae00516f9e2edec9439cb7fd680006ea88",
+        "rev": "d00ee7080fa9375e959eb44035bd068c9900e62b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.