### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786373665,
-        "narHash": "sha256-518fFOUG71b8x04Chs44Qnzvpvk2HFfktDyAaCkYuy4=",
+        "lastModified": 1786378179,
+        "narHash": "sha256-1Y8HsukaGyD3ySxQfZoeWhwbkc5gV9JNQHRS5rfEddM=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "8f5c6573aa7104bab342f48d48ada6a5f11b1ac0",
+        "rev": "7f48416a1f8b2225db7997b81c7db85e546ac9ed",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786373665,
-        "narHash": "sha256-518fFOUG71b8x04Chs44Qnzvpvk2HFfktDyAaCkYuy4=",
+        "lastModified": 1786378179,
+        "narHash": "sha256-1Y8HsukaGyD3ySxQfZoeWhwbkc5gV9JNQHRS5rfEddM=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "8f5c6573aa7104bab342f48d48ada6a5f11b1ac0",
+        "rev": "7f48416a1f8b2225db7997b81c7db85e546ac9ed",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786373665,
-        "narHash": "sha256-518fFOUG71b8x04Chs44Qnzvpvk2HFfktDyAaCkYuy4=",
+        "lastModified": 1786378179,
+        "narHash": "sha256-1Y8HsukaGyD3ySxQfZoeWhwbkc5gV9JNQHRS5rfEddM=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "8f5c6573aa7104bab342f48d48ada6a5f11b1ac0",
+        "rev": "7f48416a1f8b2225db7997b81c7db85e546ac9ed",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786373665,
-        "narHash": "sha256-518fFOUG71b8x04Chs44Qnzvpvk2HFfktDyAaCkYuy4=",
+        "lastModified": 1786378179,
+        "narHash": "sha256-1Y8HsukaGyD3ySxQfZoeWhwbkc5gV9JNQHRS5rfEddM=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "8f5c6573aa7104bab342f48d48ada6a5f11b1ac0",
+        "rev": "7f48416a1f8b2225db7997b81c7db85e546ac9ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.