### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786430214,
-        "narHash": "sha256-yF9eMxJriLvo/2r7UObjkHSq80yieVppWewaJpPTS7k=",
+        "lastModified": 1786430639,
+        "narHash": "sha256-Wc8kW1wGqmM5mhVdvFqjXgFJ+x0Ms0ficVdt00OdO3I=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "f893ee39a72d48d12ad2e8a7a79901c54c9f3e50",
+        "rev": "76fe6dd62cce74415848d39235c9425b05a18e79",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786430214,
-        "narHash": "sha256-yF9eMxJriLvo/2r7UObjkHSq80yieVppWewaJpPTS7k=",
+        "lastModified": 1786430639,
+        "narHash": "sha256-Wc8kW1wGqmM5mhVdvFqjXgFJ+x0Ms0ficVdt00OdO3I=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "f893ee39a72d48d12ad2e8a7a79901c54c9f3e50",
+        "rev": "76fe6dd62cce74415848d39235c9425b05a18e79",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786430214,
-        "narHash": "sha256-yF9eMxJriLvo/2r7UObjkHSq80yieVppWewaJpPTS7k=",
+        "lastModified": 1786430639,
+        "narHash": "sha256-Wc8kW1wGqmM5mhVdvFqjXgFJ+x0Ms0ficVdt00OdO3I=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "f893ee39a72d48d12ad2e8a7a79901c54c9f3e50",
+        "rev": "76fe6dd62cce74415848d39235c9425b05a18e79",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786430214,
-        "narHash": "sha256-yF9eMxJriLvo/2r7UObjkHSq80yieVppWewaJpPTS7k=",
+        "lastModified": 1786430639,
+        "narHash": "sha256-Wc8kW1wGqmM5mhVdvFqjXgFJ+x0Ms0ficVdt00OdO3I=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "f893ee39a72d48d12ad2e8a7a79901c54c9f3e50",
+        "rev": "76fe6dd62cce74415848d39235c9425b05a18e79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.