### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786440269,
-        "narHash": "sha256-hKma+Ir34VRYW6TKu6k8FA+3WXy10TwTe8GOmDKvaEs=",
+        "lastModified": 1786441520,
+        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "881cf28fbf36ef7644f2255c38a2eb2dad9e5945",
+        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786440269,
-        "narHash": "sha256-hKma+Ir34VRYW6TKu6k8FA+3WXy10TwTe8GOmDKvaEs=",
+        "lastModified": 1786441520,
+        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "881cf28fbf36ef7644f2255c38a2eb2dad9e5945",
+        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786440269,
-        "narHash": "sha256-hKma+Ir34VRYW6TKu6k8FA+3WXy10TwTe8GOmDKvaEs=",
+        "lastModified": 1786441520,
+        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "881cf28fbf36ef7644f2255c38a2eb2dad9e5945",
+        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786440269,
-        "narHash": "sha256-hKma+Ir34VRYW6TKu6k8FA+3WXy10TwTe8GOmDKvaEs=",
+        "lastModified": 1786441520,
+        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "881cf28fbf36ef7644f2255c38a2eb2dad9e5945",
+        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.