### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786441520,
-        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
+        "lastModified": 1786445197,
+        "narHash": "sha256-KGOrMkaRMC3XsZCJ+s9WAteDeTSdUeIiaQqzUWy5fxs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
+        "rev": "5649671d2a690a68206c810ef60e2d6a19464bd8",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786441520,
-        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
+        "lastModified": 1786445197,
+        "narHash": "sha256-KGOrMkaRMC3XsZCJ+s9WAteDeTSdUeIiaQqzUWy5fxs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
+        "rev": "5649671d2a690a68206c810ef60e2d6a19464bd8",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786441520,
-        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
+        "lastModified": 1786445197,
+        "narHash": "sha256-KGOrMkaRMC3XsZCJ+s9WAteDeTSdUeIiaQqzUWy5fxs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
+        "rev": "5649671d2a690a68206c810ef60e2d6a19464bd8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786441520,
-        "narHash": "sha256-NvXy5kRz/GXQGDo2ZuFb32s+wpuuWdJ4J25gW/DKSFs=",
+        "lastModified": 1786445197,
+        "narHash": "sha256-KGOrMkaRMC3XsZCJ+s9WAteDeTSdUeIiaQqzUWy5fxs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b341fcf726dad72e74051a3816c8acd7045a2b7d",
+        "rev": "5649671d2a690a68206c810ef60e2d6a19464bd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.