### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786547854,
-        "narHash": "sha256-AtimB83ybpZuycBfEvM3oL29kVjxl2zhQDoizqqAVwE=",
+        "lastModified": 1786555114,
+        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6948369716bfe2f2c8136595b4337f4c22e823c0",
+        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786547854,
-        "narHash": "sha256-AtimB83ybpZuycBfEvM3oL29kVjxl2zhQDoizqqAVwE=",
+        "lastModified": 1786555114,
+        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6948369716bfe2f2c8136595b4337f4c22e823c0",
+        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786547854,
-        "narHash": "sha256-AtimB83ybpZuycBfEvM3oL29kVjxl2zhQDoizqqAVwE=",
+        "lastModified": 1786555114,
+        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6948369716bfe2f2c8136595b4337f4c22e823c0",
+        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786547854,
-        "narHash": "sha256-AtimB83ybpZuycBfEvM3oL29kVjxl2zhQDoizqqAVwE=",
+        "lastModified": 1786555114,
+        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6948369716bfe2f2c8136595b4337f4c22e823c0",
+        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.