### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786555114,
-        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
+        "lastModified": 1786560023,
+        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
+        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786555114,
-        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
+        "lastModified": 1786560023,
+        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
+        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786555114,
-        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
+        "lastModified": 1786560023,
+        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
+        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786555114,
-        "narHash": "sha256-f2Qd0c9U/1ak6Iddc+monZrxV/oI0rZZCCSOB4EHbkk=",
+        "lastModified": 1786560023,
+        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "eedb4ae0d6edbfbab9d95bc821216670529e3682",
+        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.