### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786560023,
-        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
+        "lastModified": 1786564171,
+        "narHash": "sha256-GTdziG7fru0SXhZXZt3tTGQL0Fzm+EpfEnJzthN+XQ4=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
+        "rev": "3252def135b35eb52b86988df15f621dd9ae9e10",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786560023,
-        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
+        "lastModified": 1786564171,
+        "narHash": "sha256-GTdziG7fru0SXhZXZt3tTGQL0Fzm+EpfEnJzthN+XQ4=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
+        "rev": "3252def135b35eb52b86988df15f621dd9ae9e10",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786560023,
-        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
+        "lastModified": 1786564171,
+        "narHash": "sha256-GTdziG7fru0SXhZXZt3tTGQL0Fzm+EpfEnJzthN+XQ4=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
+        "rev": "3252def135b35eb52b86988df15f621dd9ae9e10",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786560023,
-        "narHash": "sha256-wXQc7032hDP2qPn/n+5V8Vn8vlxG8LXBFV+alUtuvSc=",
+        "lastModified": 1786564171,
+        "narHash": "sha256-GTdziG7fru0SXhZXZt3tTGQL0Fzm+EpfEnJzthN+XQ4=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "3b6fd31a42c4b034ab83d664f6d6202acb03787d",
+        "rev": "3252def135b35eb52b86988df15f621dd9ae9e10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.