### PR TITLE
chore(nix): update portainer to 2.39.6

### DIFF
--- a/Linux/NixOS/services/portainer.nix
+++ b/Linux/NixOS/services/portainer.nix
@@ -19,7 +19,7 @@ in
         backend = "docker";
 
         containers.portainer = {
-          image = "portainer/portainer-ce:2.39.5";
+          image = "portainer/portainer-ce:2.39.6";
           autoStart = true;
           ports = [
             "127.0.0.1:9443:9443"


### PR DESCRIPTION
## What

Bumps the pinned `portainer/portainer-ce` image tag to `2.39.6`.

## Why

Keeps the deployed Portainer release current. Verified the Docker Hub tag exists before opening this PR.

## Testing

- Confirmed `portainer/portainer-ce:2.39.6` exists on Docker Hub.
- `nix eval` with `mysetup.features.portainer` force-enabled resolves the expected image string.