### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786600526,
-        "narHash": "sha256-DERBKLXDvwFZKsMmMlnu2HDCnyMvkJesqsJqxKZBXrA=",
+        "lastModified": 1786606391,
+        "narHash": "sha256-zKMyD0U6WvTL7MXrrRquJAJpKeEuSeeXmzotbD3nv/g=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb66a35e850b996d0fafe70232ae2a353ddbe5cd",
+        "rev": "4e87a13c3248015732613422b56689ff840f974b",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786600526,
-        "narHash": "sha256-DERBKLXDvwFZKsMmMlnu2HDCnyMvkJesqsJqxKZBXrA=",
+        "lastModified": 1786606391,
+        "narHash": "sha256-zKMyD0U6WvTL7MXrrRquJAJpKeEuSeeXmzotbD3nv/g=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb66a35e850b996d0fafe70232ae2a353ddbe5cd",
+        "rev": "4e87a13c3248015732613422b56689ff840f974b",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786600526,
-        "narHash": "sha256-DERBKLXDvwFZKsMmMlnu2HDCnyMvkJesqsJqxKZBXrA=",
+        "lastModified": 1786606391,
+        "narHash": "sha256-zKMyD0U6WvTL7MXrrRquJAJpKeEuSeeXmzotbD3nv/g=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb66a35e850b996d0fafe70232ae2a353ddbe5cd",
+        "rev": "4e87a13c3248015732613422b56689ff840f974b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786600526,
-        "narHash": "sha256-DERBKLXDvwFZKsMmMlnu2HDCnyMvkJesqsJqxKZBXrA=",
+        "lastModified": 1786606391,
+        "narHash": "sha256-zKMyD0U6WvTL7MXrrRquJAJpKeEuSeeXmzotbD3nv/g=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb66a35e850b996d0fafe70232ae2a353ddbe5cd",
+        "rev": "4e87a13c3248015732613422b56689ff840f974b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.