### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786636373,
-        "narHash": "sha256-m/FUw8hVtaF9b4jVQdsEUHm7VKpd0na1Ah2kTSNBXKw=",
+        "lastModified": 1786641367,
+        "narHash": "sha256-CrH6CaNoMyqrat1HmZwDJLiAplWe65gMdHqW4YZA2yc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b15860664fc360ca97541f818ac31c16ed596546",
+        "rev": "7b32aaf6c280998041654a2644387075a9ab1404",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786636373,
-        "narHash": "sha256-m/FUw8hVtaF9b4jVQdsEUHm7VKpd0na1Ah2kTSNBXKw=",
+        "lastModified": 1786641367,
+        "narHash": "sha256-CrH6CaNoMyqrat1HmZwDJLiAplWe65gMdHqW4YZA2yc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b15860664fc360ca97541f818ac31c16ed596546",
+        "rev": "7b32aaf6c280998041654a2644387075a9ab1404",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786636373,
-        "narHash": "sha256-m/FUw8hVtaF9b4jVQdsEUHm7VKpd0na1Ah2kTSNBXKw=",
+        "lastModified": 1786641367,
+        "narHash": "sha256-CrH6CaNoMyqrat1HmZwDJLiAplWe65gMdHqW4YZA2yc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b15860664fc360ca97541f818ac31c16ed596546",
+        "rev": "7b32aaf6c280998041654a2644387075a9ab1404",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786636373,
-        "narHash": "sha256-m/FUw8hVtaF9b4jVQdsEUHm7VKpd0na1Ah2kTSNBXKw=",
+        "lastModified": 1786641367,
+        "narHash": "sha256-CrH6CaNoMyqrat1HmZwDJLiAplWe65gMdHqW4YZA2yc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "b15860664fc360ca97541f818ac31c16ed596546",
+        "rev": "7b32aaf6c280998041654a2644387075a9ab1404",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.