### PR TITLE
chore(nix): update Claude Desktop to 1.30096.1

### DIFF
--- a/Linux/NixOS/pkgs/claude-desktop-source.nix
+++ b/Linux/NixOS/pkgs/claude-desktop-source.nix
@@ -1,10 +1,10 @@
 {
-  version = "1.28929.0";
+  version = "1.30096.1";
 
   sources = {
     x86_64-linux = {
-      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.28929.0_amd64.deb";
-      hash = "sha256-POs5Emi96af+wyUg00m3BAQxZiBM3VccYtHpUHAfSPw=";
+      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.30096.1_amd64.deb";
+      hash = "sha256-CeQaIKW0fqDlvCJtT/+nevQ61FDHy/XmblbW5P1K0uk=";
     };
   };
 }


### PR DESCRIPTION
## What

Updates the pinned official Claude Desktop Linux package to `1.30096.1`.

## Verification

- Verified Anthropic's pinned signing-key fingerprint.
- Verified the APT `InRelease` signature.
- Verified the `Packages` file against its signed SHA256.
- Built the updated Wahrwelt package with the signed package SHA256.