### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786736374,
-        "narHash": "sha256-ajf3HZ0reQYFhB9ZIX/d3DBoTKiZVVnE3hnTuoq+zzw=",
+        "lastModified": 1786777492,
+        "narHash": "sha256-A5QLAostL5k3CBz7XoDgs8k3lMp6tVe+WGel4GMaZCo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6bd381696abe551effda853cfa11da94a1730b4c",
+        "rev": "bad416494f7351bc027c87eca0582d3589678ba9",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786736374,
-        "narHash": "sha256-ajf3HZ0reQYFhB9ZIX/d3DBoTKiZVVnE3hnTuoq+zzw=",
+        "lastModified": 1786777492,
+        "narHash": "sha256-A5QLAostL5k3CBz7XoDgs8k3lMp6tVe+WGel4GMaZCo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6bd381696abe551effda853cfa11da94a1730b4c",
+        "rev": "bad416494f7351bc027c87eca0582d3589678ba9",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786736374,
-        "narHash": "sha256-ajf3HZ0reQYFhB9ZIX/d3DBoTKiZVVnE3hnTuoq+zzw=",
+        "lastModified": 1786777492,
+        "narHash": "sha256-A5QLAostL5k3CBz7XoDgs8k3lMp6tVe+WGel4GMaZCo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6bd381696abe551effda853cfa11da94a1730b4c",
+        "rev": "bad416494f7351bc027c87eca0582d3589678ba9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786736374,
-        "narHash": "sha256-ajf3HZ0reQYFhB9ZIX/d3DBoTKiZVVnE3hnTuoq+zzw=",
+        "lastModified": 1786777492,
+        "narHash": "sha256-A5QLAostL5k3CBz7XoDgs8k3lMp6tVe+WGel4GMaZCo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6bd381696abe551effda853cfa11da94a1730b4c",
+        "rev": "bad416494f7351bc027c87eca0582d3589678ba9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.