### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786788830,
-        "narHash": "sha256-AwCUMB6sBVEFzj6K46z9EU8XolXKiECZ1vW/P6nvdMA=",
+        "lastModified": 1786811632,
+        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c3389ec2eae5af1741627dff014439c31dc2de61",
+        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786788830,
-        "narHash": "sha256-AwCUMB6sBVEFzj6K46z9EU8XolXKiECZ1vW/P6nvdMA=",
+        "lastModified": 1786811632,
+        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c3389ec2eae5af1741627dff014439c31dc2de61",
+        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786788830,
-        "narHash": "sha256-AwCUMB6sBVEFzj6K46z9EU8XolXKiECZ1vW/P6nvdMA=",
+        "lastModified": 1786811632,
+        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c3389ec2eae5af1741627dff014439c31dc2de61",
+        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786788830,
-        "narHash": "sha256-AwCUMB6sBVEFzj6K46z9EU8XolXKiECZ1vW/P6nvdMA=",
+        "lastModified": 1786811632,
+        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c3389ec2eae5af1741627dff014439c31dc2de61",
+        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.