### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786811632,
-        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
+        "lastModified": 1786814143,
+        "narHash": "sha256-Xjiq74yNnNhFaQ9E6eOS0yhzouhdufKMLzmUiZbL3Yg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
+        "rev": "f362dfe08adea32f8a59a6302a2018cf71bd00da",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786811632,
-        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
+        "lastModified": 1786814143,
+        "narHash": "sha256-Xjiq74yNnNhFaQ9E6eOS0yhzouhdufKMLzmUiZbL3Yg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
+        "rev": "f362dfe08adea32f8a59a6302a2018cf71bd00da",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786811632,
-        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
+        "lastModified": 1786814143,
+        "narHash": "sha256-Xjiq74yNnNhFaQ9E6eOS0yhzouhdufKMLzmUiZbL3Yg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
+        "rev": "f362dfe08adea32f8a59a6302a2018cf71bd00da",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786811632,
-        "narHash": "sha256-jSO/BRppY5FsaHK2TrYPgR9AcSJsPpYEwwRMUmRTEtw=",
+        "lastModified": 1786814143,
+        "narHash": "sha256-Xjiq74yNnNhFaQ9E6eOS0yhzouhdufKMLzmUiZbL3Yg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "87aa59c3d0559d1b6aa9fe074ca2d88217e2ba43",
+        "rev": "f362dfe08adea32f8a59a6302a2018cf71bd00da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.