### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787061828,
-        "narHash": "sha256-5AD20Wi2mAZjtMVzfVJgfpae5tz9MQMm2+r5s1VqERo=",
+        "lastModified": 1787066639,
+        "narHash": "sha256-tyu5Iy3ogc77SXhXKudA0W/E/qTXO/q0zEXKiloN+Is=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "784b05aef45f5351bee4a1ffbcf1087d715f3c68",
+        "rev": "fff4e5a186ab9bd714adec92f48b59f6d8057376",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787061828,
-        "narHash": "sha256-5AD20Wi2mAZjtMVzfVJgfpae5tz9MQMm2+r5s1VqERo=",
+        "lastModified": 1787066639,
+        "narHash": "sha256-tyu5Iy3ogc77SXhXKudA0W/E/qTXO/q0zEXKiloN+Is=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "784b05aef45f5351bee4a1ffbcf1087d715f3c68",
+        "rev": "fff4e5a186ab9bd714adec92f48b59f6d8057376",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787061828,
-        "narHash": "sha256-5AD20Wi2mAZjtMVzfVJgfpae5tz9MQMm2+r5s1VqERo=",
+        "lastModified": 1787066639,
+        "narHash": "sha256-tyu5Iy3ogc77SXhXKudA0W/E/qTXO/q0zEXKiloN+Is=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "784b05aef45f5351bee4a1ffbcf1087d715f3c68",
+        "rev": "fff4e5a186ab9bd714adec92f48b59f6d8057376",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787061828,
-        "narHash": "sha256-5AD20Wi2mAZjtMVzfVJgfpae5tz9MQMm2+r5s1VqERo=",
+        "lastModified": 1787066639,
+        "narHash": "sha256-tyu5Iy3ogc77SXhXKudA0W/E/qTXO/q0zEXKiloN+Is=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "784b05aef45f5351bee4a1ffbcf1087d715f3c68",
+        "rev": "fff4e5a186ab9bd714adec92f48b59f6d8057376",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.