### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787237827,
-        "narHash": "sha256-UL+zfPhwR5vcRdyMSY4kjS5hmLki9e3ycp15hyLaU5U=",
+        "lastModified": 1787241724,
+        "narHash": "sha256-OF4G16kv8lJr7RdeqC89oM4V+um7KWe5YlQlQTq5yJs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7ee3b5ea6ffe410803a1f7ef836136aaee822aec",
+        "rev": "bf286d02a6f8866d5f5da90b582410f5fc77f86e",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787237827,
-        "narHash": "sha256-UL+zfPhwR5vcRdyMSY4kjS5hmLki9e3ycp15hyLaU5U=",
+        "lastModified": 1787241724,
+        "narHash": "sha256-OF4G16kv8lJr7RdeqC89oM4V+um7KWe5YlQlQTq5yJs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7ee3b5ea6ffe410803a1f7ef836136aaee822aec",
+        "rev": "bf286d02a6f8866d5f5da90b582410f5fc77f86e",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787237827,
-        "narHash": "sha256-UL+zfPhwR5vcRdyMSY4kjS5hmLki9e3ycp15hyLaU5U=",
+        "lastModified": 1787241724,
+        "narHash": "sha256-OF4G16kv8lJr7RdeqC89oM4V+um7KWe5YlQlQTq5yJs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7ee3b5ea6ffe410803a1f7ef836136aaee822aec",
+        "rev": "bf286d02a6f8866d5f5da90b582410f5fc77f86e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787237827,
-        "narHash": "sha256-UL+zfPhwR5vcRdyMSY4kjS5hmLki9e3ycp15hyLaU5U=",
+        "lastModified": 1787241724,
+        "narHash": "sha256-OF4G16kv8lJr7RdeqC89oM4V+um7KWe5YlQlQTq5yJs=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7ee3b5ea6ffe410803a1f7ef836136aaee822aec",
+        "rev": "bf286d02a6f8866d5f5da90b582410f5fc77f86e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.