### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787267418,
-        "narHash": "sha256-jMAqUwoSc8M5wyAB80FySJicedqS91XlWhLupK5YD1U=",
+        "lastModified": 1787310585,
+        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "0709a9e92609f603b22cd8059c276956716a3960",
+        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787267418,
-        "narHash": "sha256-jMAqUwoSc8M5wyAB80FySJicedqS91XlWhLupK5YD1U=",
+        "lastModified": 1787310585,
+        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "0709a9e92609f603b22cd8059c276956716a3960",
+        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787267418,
-        "narHash": "sha256-jMAqUwoSc8M5wyAB80FySJicedqS91XlWhLupK5YD1U=",
+        "lastModified": 1787310585,
+        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "0709a9e92609f603b22cd8059c276956716a3960",
+        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787267418,
-        "narHash": "sha256-jMAqUwoSc8M5wyAB80FySJicedqS91XlWhLupK5YD1U=",
+        "lastModified": 1787310585,
+        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "0709a9e92609f603b22cd8059c276956716a3960",
+        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.