### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787310585,
-        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
+        "lastModified": 1787327314,
+        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
+        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787310585,
-        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
+        "lastModified": 1787327314,
+        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
+        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787310585,
-        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
+        "lastModified": 1787327314,
+        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
+        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787310585,
-        "narHash": "sha256-lJBYDDb1mmBQPcCztbRdOYOmGrsXOERpYAVoSgKZFt8=",
+        "lastModified": 1787327314,
+        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "e46e3c646151db786f85712ade10e4673bd807e4",
+        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.