### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787327314,
-        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
+        "lastModified": 1787360996,
+        "narHash": "sha256-/BeFWSU6mhBvy5luY30tj5ILEnnYLqaxCN+JvnrvQsA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
+        "rev": "f496bbd45ded8f7075a7bef44837345a34a631a9",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787327314,
-        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
+        "lastModified": 1787360996,
+        "narHash": "sha256-/BeFWSU6mhBvy5luY30tj5ILEnnYLqaxCN+JvnrvQsA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
+        "rev": "f496bbd45ded8f7075a7bef44837345a34a631a9",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787327314,
-        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
+        "lastModified": 1787360996,
+        "narHash": "sha256-/BeFWSU6mhBvy5luY30tj5ILEnnYLqaxCN+JvnrvQsA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
+        "rev": "f496bbd45ded8f7075a7bef44837345a34a631a9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787327314,
-        "narHash": "sha256-cdysuWt+URMdRIez15jGin2ZSs2/HTOwE42aYbKxyMc=",
+        "lastModified": 1787360996,
+        "narHash": "sha256-/BeFWSU6mhBvy5luY30tj5ILEnnYLqaxCN+JvnrvQsA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "804d33809adc33b1eaea6805d6ee599b4e79144d",
+        "rev": "f496bbd45ded8f7075a7bef44837345a34a631a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.