### PR TITLE
chore(nix): update Claude Desktop to 1.34493.1

### DIFF
--- a/Linux/NixOS/pkgs/claude-desktop-source.nix
+++ b/Linux/NixOS/pkgs/claude-desktop-source.nix
@@ -1,10 +1,10 @@
 {
-  version = "1.32885.1";
+  version = "1.34493.1";
 
   sources = {
     x86_64-linux = {
-      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.32885.1_amd64.deb";
-      hash = "sha256-+KXd6nyMvnaVic8ZwuGDLV1TKrGb+CAmIbqVfJNRovw=";
+      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.34493.1_amd64.deb";
+      hash = "sha256-GYKXeWM6J3/NcqZYNCbGik7P96pDomcY1mRcLpVHR8o=";
     };
   };
 }


### PR DESCRIPTION
## What

Updates the pinned official Claude Desktop Linux package to `1.34493.1`.

## Verification

- Verified Anthropic's pinned signing-key fingerprint.
- Verified the APT `InRelease` signature.
- Verified the `Packages` file against its signed SHA256.
- Built the updated Wahrwelt package with the signed package SHA256.