### PR TITLE
chore(nix): update Claude Desktop to 1.37937.3

### DIFF
--- a/Linux/NixOS/pkgs/claude-desktop-source.nix
+++ b/Linux/NixOS/pkgs/claude-desktop-source.nix
@@ -1,10 +1,10 @@
 {
-  version = "1.37937.1";
+  version = "1.37937.3";
 
   sources = {
     x86_64-linux = {
-      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.37937.1_amd64.deb";
-      hash = "sha256-ZrvGHdBGS1UMTWOBJSARnoNEtGJUHeRHlzUriRiEL08=";
+      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.37937.3_amd64.deb";
+      hash = "sha256-U1kMVyX7NIcpn5QPW4nVUYKw+u4Uyhvz41utrg9hE18=";
     };
   };
 }


### PR DESCRIPTION
## What

Updates the pinned official Claude Desktop Linux package to `1.37937.3`.

## Verification

- Verified Anthropic's pinned signing-key fingerprint.
- Verified the APT `InRelease` signature.
- Verified the `Packages` file against its signed SHA256.
- Built the updated Wahrwelt package with the signed package SHA256.