### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788327105,
-        "narHash": "sha256-rm2NxhIqbd13IM7YToRsk8rKAT+Fmge/+M5iwg9wONA=",
+        "lastModified": 1788378935,
+        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6fbd37aca34fd82f315b6f89aed5999a2d9425df",
+        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788327105,
-        "narHash": "sha256-rm2NxhIqbd13IM7YToRsk8rKAT+Fmge/+M5iwg9wONA=",
+        "lastModified": 1788378935,
+        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6fbd37aca34fd82f315b6f89aed5999a2d9425df",
+        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788327105,
-        "narHash": "sha256-rm2NxhIqbd13IM7YToRsk8rKAT+Fmge/+M5iwg9wONA=",
+        "lastModified": 1788378935,
+        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6fbd37aca34fd82f315b6f89aed5999a2d9425df",
+        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788327105,
-        "narHash": "sha256-rm2NxhIqbd13IM7YToRsk8rKAT+Fmge/+M5iwg9wONA=",
+        "lastModified": 1788378935,
+        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "6fbd37aca34fd82f315b6f89aed5999a2d9425df",
+        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.