### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788378935,
-        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
+        "lastModified": 1788409870,
+        "narHash": "sha256-ElkvLN3kib5ZjyVSU+3d0OGbivLhP5FYhVB/Usxq+vo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
+        "rev": "aac6178310572576a0a2785efb779b5b4bdf639f",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788378935,
-        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
+        "lastModified": 1788409870,
+        "narHash": "sha256-ElkvLN3kib5ZjyVSU+3d0OGbivLhP5FYhVB/Usxq+vo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
+        "rev": "aac6178310572576a0a2785efb779b5b4bdf639f",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788378935,
-        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
+        "lastModified": 1788409870,
+        "narHash": "sha256-ElkvLN3kib5ZjyVSU+3d0OGbivLhP5FYhVB/Usxq+vo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
+        "rev": "aac6178310572576a0a2785efb779b5b4bdf639f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788378935,
-        "narHash": "sha256-/PwI+2iNoaKA5ms9XhlxDAC9nMhNh3eY9j3jF7yjn2M=",
+        "lastModified": 1788409870,
+        "narHash": "sha256-ElkvLN3kib5ZjyVSU+3d0OGbivLhP5FYhVB/Usxq+vo=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7b3c12fb0f513c2ec5f2a420f457a1edc6753e87",
+        "rev": "aac6178310572576a0a2785efb779b5b4bdf639f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.