### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788474440,
-        "narHash": "sha256-yDA8UwoFlw3UbDS66wo53cYFQ7s/QY1qn5FpdZAD2fQ=",
+        "lastModified": 1788502697,
+        "narHash": "sha256-mcH7gBS8XjG+PB8GRQQki4LPwbflatADXBQImsKowzQ=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "fbc4d68119002792484e4f944436851deca55db7",
+        "rev": "d15120958546a5f73d61f1f765dbe114440dcf70",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788474440,
-        "narHash": "sha256-yDA8UwoFlw3UbDS66wo53cYFQ7s/QY1qn5FpdZAD2fQ=",
+        "lastModified": 1788502697,
+        "narHash": "sha256-mcH7gBS8XjG+PB8GRQQki4LPwbflatADXBQImsKowzQ=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "fbc4d68119002792484e4f944436851deca55db7",
+        "rev": "d15120958546a5f73d61f1f765dbe114440dcf70",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788474440,
-        "narHash": "sha256-yDA8UwoFlw3UbDS66wo53cYFQ7s/QY1qn5FpdZAD2fQ=",
+        "lastModified": 1788502697,
+        "narHash": "sha256-mcH7gBS8XjG+PB8GRQQki4LPwbflatADXBQImsKowzQ=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "fbc4d68119002792484e4f944436851deca55db7",
+        "rev": "d15120958546a5f73d61f1f765dbe114440dcf70",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788474440,
-        "narHash": "sha256-yDA8UwoFlw3UbDS66wo53cYFQ7s/QY1qn5FpdZAD2fQ=",
+        "lastModified": 1788502697,
+        "narHash": "sha256-mcH7gBS8XjG+PB8GRQQki4LPwbflatADXBQImsKowzQ=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "fbc4d68119002792484e4f944436851deca55db7",
+        "rev": "d15120958546a5f73d61f1f765dbe114440dcf70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.