### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788560091,
-        "narHash": "sha256-Z7pyOw3IzZWyx/FMJOER8Pfh9f5ucs7SQ17jOWXQmf8=",
+        "lastModified": 1788577527,
+        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "70662cbe6f59c2b42b17e86a80a00c3a0760a75c",
+        "rev": "9845401c504a048f3814687562017a004378ef32",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788560091,
-        "narHash": "sha256-Z7pyOw3IzZWyx/FMJOER8Pfh9f5ucs7SQ17jOWXQmf8=",
+        "lastModified": 1788577527,
+        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "70662cbe6f59c2b42b17e86a80a00c3a0760a75c",
+        "rev": "9845401c504a048f3814687562017a004378ef32",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788560091,
-        "narHash": "sha256-Z7pyOw3IzZWyx/FMJOER8Pfh9f5ucs7SQ17jOWXQmf8=",
+        "lastModified": 1788577527,
+        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "70662cbe6f59c2b42b17e86a80a00c3a0760a75c",
+        "rev": "9845401c504a048f3814687562017a004378ef32",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788560091,
-        "narHash": "sha256-Z7pyOw3IzZWyx/FMJOER8Pfh9f5ucs7SQ17jOWXQmf8=",
+        "lastModified": 1788577527,
+        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "70662cbe6f59c2b42b17e86a80a00c3a0760a75c",
+        "rev": "9845401c504a048f3814687562017a004378ef32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.