### PR TITLE
chore(nix): update Claude Desktop to 1.46388.2

### DIFF
--- a/Linux/NixOS/pkgs/claude-desktop-source.nix
+++ b/Linux/NixOS/pkgs/claude-desktop-source.nix
@@ -1,10 +1,10 @@
 {
-  version = "1.40609.1";
+  version = "1.46388.2";
 
   sources = {
     x86_64-linux = {
-      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.40609.1_amd64.deb";
-      hash = "sha256-gBguhRHGu+5t4mx+4iX70qmroidO8UBaHYnNj+ejgNw=";
+      url = "https://downloads.claude.ai/claude-desktop/apt/stable/pool/main/c/claude-desktop/claude-desktop_1.46388.2_amd64.deb";
+      hash = "sha256-mL9U6F5JFgaMQoFFmw8EMdj/aANHc/PumDEdcgZWarE=";
     };
   };
 }


### PR DESCRIPTION
## What

Updates the pinned official Claude Desktop Linux package to `1.46388.2`.

## Verification

- Verified Anthropic's pinned signing-key fingerprint.
- Verified the APT `InRelease` signature.
- Verified the `Packages` file against its signed SHA256.
- Built the updated Wahrwelt package with the signed package SHA256.