### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788577527,
-        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
+        "lastModified": 1788585453,
+        "narHash": "sha256-Uuy2VldrQmsQqUmkg5A75P5JCzbQSe4PQDROjK6Ist0=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "9845401c504a048f3814687562017a004378ef32",
+        "rev": "bb421378b2526bab60315bfb277a9625e003834d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788577527,
-        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
+        "lastModified": 1788585453,
+        "narHash": "sha256-Uuy2VldrQmsQqUmkg5A75P5JCzbQSe4PQDROjK6Ist0=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "9845401c504a048f3814687562017a004378ef32",
+        "rev": "bb421378b2526bab60315bfb277a9625e003834d",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788577527,
-        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
+        "lastModified": 1788585453,
+        "narHash": "sha256-Uuy2VldrQmsQqUmkg5A75P5JCzbQSe4PQDROjK6Ist0=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "9845401c504a048f3814687562017a004378ef32",
+        "rev": "bb421378b2526bab60315bfb277a9625e003834d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788577527,
-        "narHash": "sha256-FfyIPTmpGzZX2uYpko4hgfcojLJh2Jax6pZlwPqgVpg=",
+        "lastModified": 1788585453,
+        "narHash": "sha256-Uuy2VldrQmsQqUmkg5A75P5JCzbQSe4PQDROjK6Ist0=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "9845401c504a048f3814687562017a004378ef32",
+        "rev": "bb421378b2526bab60315bfb277a9625e003834d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.