### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788866765,
-        "narHash": "sha256-3/uYCQOJd73hiPubcMmufBz8Kw3kVp+kEnLi+6nNKog=",
+        "lastModified": 1788869021,
+        "narHash": "sha256-r9UZhL3Isqlw8e6iNuoqGo6BxqqBEuYEDDWY939SiOk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c0e8e42bc0bf96088776e9a771b57610efb9e588",
+        "rev": "99aa2b653cc6db855957058a602da3139d50feb8",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788866765,
-        "narHash": "sha256-3/uYCQOJd73hiPubcMmufBz8Kw3kVp+kEnLi+6nNKog=",
+        "lastModified": 1788869021,
+        "narHash": "sha256-r9UZhL3Isqlw8e6iNuoqGo6BxqqBEuYEDDWY939SiOk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c0e8e42bc0bf96088776e9a771b57610efb9e588",
+        "rev": "99aa2b653cc6db855957058a602da3139d50feb8",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788866765,
-        "narHash": "sha256-3/uYCQOJd73hiPubcMmufBz8Kw3kVp+kEnLi+6nNKog=",
+        "lastModified": 1788869021,
+        "narHash": "sha256-r9UZhL3Isqlw8e6iNuoqGo6BxqqBEuYEDDWY939SiOk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c0e8e42bc0bf96088776e9a771b57610efb9e588",
+        "rev": "99aa2b653cc6db855957058a602da3139d50feb8",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788866765,
-        "narHash": "sha256-3/uYCQOJd73hiPubcMmufBz8Kw3kVp+kEnLi+6nNKog=",
+        "lastModified": 1788869021,
+        "narHash": "sha256-r9UZhL3Isqlw8e6iNuoqGo6BxqqBEuYEDDWY939SiOk=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "c0e8e42bc0bf96088776e9a771b57610efb9e588",
+        "rev": "99aa2b653cc6db855957058a602da3139d50feb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.