### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788883522,
-        "narHash": "sha256-X+XWaNa7uuiIVXspVzvCpWRlKxVwAVI6ZOIQTUAZhBE=",
+        "lastModified": 1788929289,
+        "narHash": "sha256-UMbEzZmkIWK9zZatdeWaRvNdjGATM0l8taxvtEEhbPA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb40cf5e1cec8df665d85c04390d37c54603a56b",
+        "rev": "10cf6241eba303a274b4a6f5a46d605c54d07adc",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788883522,
-        "narHash": "sha256-X+XWaNa7uuiIVXspVzvCpWRlKxVwAVI6ZOIQTUAZhBE=",
+        "lastModified": 1788929289,
+        "narHash": "sha256-UMbEzZmkIWK9zZatdeWaRvNdjGATM0l8taxvtEEhbPA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb40cf5e1cec8df665d85c04390d37c54603a56b",
+        "rev": "10cf6241eba303a274b4a6f5a46d605c54d07adc",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -194,11 +194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788883522,
-        "narHash": "sha256-X+XWaNa7uuiIVXspVzvCpWRlKxVwAVI6ZOIQTUAZhBE=",
+        "lastModified": 1788929289,
+        "narHash": "sha256-UMbEzZmkIWK9zZatdeWaRvNdjGATM0l8taxvtEEhbPA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb40cf5e1cec8df665d85c04390d37c54603a56b",
+        "rev": "10cf6241eba303a274b4a6f5a46d605c54d07adc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788883522,
-        "narHash": "sha256-X+XWaNa7uuiIVXspVzvCpWRlKxVwAVI6ZOIQTUAZhBE=",
+        "lastModified": 1788929289,
+        "narHash": "sha256-UMbEzZmkIWK9zZatdeWaRvNdjGATM0l8taxvtEEhbPA=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "bb40cf5e1cec8df665d85c04390d37c54603a56b",
+        "rev": "10cf6241eba303a274b4a6f5a46d605c54d07adc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.