### PR TITLE
chore(nix): update Codex Desktop

### DIFF
--- a/Linux/NixOS/flake.lock
+++ b/Linux/NixOS/flake.lock
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789037969,
-        "narHash": "sha256-OiLQ5JZEkAn8acV+7MDfj61oNBvZGooU1k3+OaNc8UQ=",
+        "lastModified": 1789049627,
+        "narHash": "sha256-B0HMTL48T1CsQBgOF4JPeHMu3RUi+wdy6cwsVoOCsQU=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7f0a4d9961a064cebb1561bd6f3fde5396ca0e43",
+        "rev": "6ef7b48fae291d1b23cbaa2f9d71b8897e2c7095",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/developer/flake.lock
+++ b/Linux/NixOS/presets/developer/flake.lock
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789037969,
-        "narHash": "sha256-OiLQ5JZEkAn8acV+7MDfj61oNBvZGooU1k3+OaNc8UQ=",
+        "lastModified": 1789049627,
+        "narHash": "sha256-B0HMTL48T1CsQBgOF4JPeHMu3RUi+wdy6cwsVoOCsQU=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7f0a4d9961a064cebb1561bd6f3fde5396ca0e43",
+        "rev": "6ef7b48fae291d1b23cbaa2f9d71b8897e2c7095",
         "type": "github"
       },
       "original": {

--- a/Linux/NixOS/presets/personal/flake.lock
+++ b/Linux/NixOS/presets/personal/flake.lock
@@ -211,11 +211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789037969,
-        "narHash": "sha256-OiLQ5JZEkAn8acV+7MDfj61oNBvZGooU1k3+OaNc8UQ=",
+        "lastModified": 1789049627,
+        "narHash": "sha256-B0HMTL48T1CsQBgOF4JPeHMu3RUi+wdy6cwsVoOCsQU=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7f0a4d9961a064cebb1561bd6f3fde5396ca0e43",
+        "rev": "6ef7b48fae291d1b23cbaa2f9d71b8897e2c7095",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -187,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789037969,
-        "narHash": "sha256-OiLQ5JZEkAn8acV+7MDfj61oNBvZGooU1k3+OaNc8UQ=",
+        "lastModified": 1789049627,
+        "narHash": "sha256-B0HMTL48T1CsQBgOF4JPeHMu3RUi+wdy6cwsVoOCsQU=",
         "owner": "ilysenko",
         "repo": "codex-desktop-linux",
-        "rev": "7f0a4d9961a064cebb1561bd6f3fde5396ca0e43",
+        "rev": "6ef7b48fae291d1b23cbaa2f9d71b8897e2c7095",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Refreshes the immutable `ilysenko/codex-desktop-linux` revision in every lock that owns it.

## Verification

- Resolved upstream Git `HEAD` to an exact commit.
- Verified all managed locks resolve to that same commit.
- Evaluated the developer preset without building unrelated packages.
- Built the upstream Codex Desktop package, including its mutable DMG hash check.